### PR TITLE
Trick RPython into automatically widening ops to Unsigned

### DIFF
--- a/emulator/test/conftest.py
+++ b/emulator/test/conftest.py
@@ -1,0 +1,21 @@
+
+option = None
+
+
+def pytest_configure(config):
+    global option
+    option = config.option
+
+    import rpython.conftest
+    rpython.conftest.option = option
+
+
+def pytest_addoption(parser):
+    parser.addoption('--view', action="store_true", dest="view", default=False,
+           help="view translation tests' flow graphs with Pygame")
+    parser.addoption('--viewloops', action="store_true",
+           default=False, dest="viewloops",
+           help="show only the compiled loops")
+    parser.addoption('--viewdeps', action="store_true",
+           default=False, dest="viewdeps",
+           help="show the dependencies that have been constructed from a trace")

--- a/emulator/test/test_types.py
+++ b/emulator/test/test_types.py
@@ -1,20 +1,192 @@
+from rpython.annotator.listdef import s_list_of_strings
+from rpython.jit.metainterp.test.support import LLJitMixin
+from rpython.rlib import rbigint
+from rpython.rlib.jit import JitDriver
+from rpython.translator.c.genc import CStandaloneBuilder
+from rpython.translator.translator import TranslationContext
 
+from emulator.test.conftest import option
 from emulator.types import *
 
 
-class TestTypes:
-    def test_uint8(self):
-        x = uint8_t(0)
-        assert x == 0
-        x += 127
-        assert x == 127
-        x += 128
-        assert x == 255
-        x += 1
-        assert x == 0
-        x -= 1
-        assert x == 255
-        x <<= 1
-        assert x == 254
-        x >>= 1
-        assert x == 127
+binop_d = {}
+binop_l = []
+
+
+def binop_f(op, a, b):
+    return binop_l[op](a, b)
+
+
+def def_binop(op):
+    exec "def w(a, b):\n return a %s b" % op
+    binop_d[op] = len(binop_l)
+    binop_l.append(w)
+
+
+def binop(f, op):
+    i = binop_d[op]
+    def impl(a, b):
+        return f(i, a, b)
+    return impl
+
+
+def_binop('+')
+def_binop('-')
+def_binop('*')
+# def_binop('/')
+# def_binop('%')
+def_binop('<<')
+def_binop('>>')
+def_binop('&')
+def_binop('^')
+def_binop('|')
+
+
+class TestEmulated:
+    def compile(self, f, a, r):
+        def wrap(*v):
+            assert len(v) == len(a)
+            for i, x in enumerate(v):
+                assert type(x) is a[i]
+            o = f(*v)
+            assert type(o) is r
+            return o
+        return wrap
+
+    def test_binop_uint8_uint8(self):
+        f = self.compile(binop_f, [int, uint8_t, uint8_t], uint8_t)
+        assert binop(f, '+')(uint8_t(255), uint8_t(255)) == uint8_t(254)
+        assert binop(f, '-')(uint8_t(1), uint8_t(255)) == uint8_t(2)
+        assert binop(f, '*')(uint8_t(255), uint8_t(255)) == uint8_t(1)
+        # assert binop(f, '/')(uint8_t(255), uint8_t(2)) == uint8_t(127)
+        # assert binop(f, '/')(uint8_t(255), uint8_t(255)) == uint8_t(1)
+        # assert binop(f, '%')(uint8_t(255), uint8_t(4)) == uint8_t(3)
+        # assert binop(f, '%')(uint8_t(255), uint8_t(254)) == uint8_t(1)
+        assert binop(f, '<<')(uint8_t(255), uint8_t(0)) == uint8_t(255)
+        assert binop(f, '<<')(uint8_t(255), uint8_t(2)) == uint8_t(252)
+        assert binop(f, '<<')(uint8_t(255), uint8_t(8)) == uint8_t(0)
+        assert binop(f, '>>')(uint8_t(255), uint8_t(0)) == uint8_t(255)
+        assert binop(f, '>>')(uint8_t(255), uint8_t(2)) == uint8_t(63)
+        assert binop(f, '>>')(uint8_t(255), uint8_t(8)) == uint8_t(0)
+        assert binop(f, '&')(uint8_t(0xA5), uint8_t(0xAA)) == uint8_t(0xA0)
+        assert binop(f, '^')(uint8_t(0xA5), uint8_t(0xAA)) == uint8_t(0x0F)
+        assert binop(f, '|')(uint8_t(0xA5), uint8_t(0xAA)) == uint8_t(0xAF)
+
+    def test_binop_uint16_uint16(self):
+        f = self.compile(binop_f, [int, uint16_t, uint16_t], uint16_t)
+        assert binop(f, '+')(uint16_t(2**16-1), uint16_t(2**16-1)) == uint16_t(2**16-2)
+        assert binop(f, '-')(uint16_t(1), uint16_t(2**16-1)) == uint16_t(2)
+        assert binop(f, '*')(uint16_t(2**16-1), uint16_t(2**16-1)) == uint16_t(1)
+        # assert binop(f, '/')(uint16_t(2**16-1), uint16_t(2)) == uint16_t(2**15-1)
+        # assert binop(f, '/')(uint16_t(2**16-1), uint16_t(2**16-1)) == uint16_t(1)
+        # assert binop(f, '%')(uint16_t(2**16-1), uint16_t(4)) == uint16_t(3)
+        # assert binop(f, '%')(uint16_t(2**16-1), uint16_t(2**16-2)) == uint16_t(1)
+        assert binop(f, '<<')(uint16_t(2**16-1), uint16_t(0)) == uint16_t(2**16-1)
+        assert binop(f, '<<')(uint16_t(2**16-1), uint16_t(2)) == uint16_t(2**16-4)
+        assert binop(f, '<<')(uint16_t(2**16-1), uint16_t(15)) == uint16_t(2**15)
+        assert binop(f, '>>')(uint16_t(2**16-1), uint16_t(0)) == uint16_t(2**16-1)
+        assert binop(f, '>>')(uint16_t(2**16-1), uint16_t(2)) == uint16_t(2**14-1)
+        assert binop(f, '>>')(uint16_t(2**16-1), uint16_t(15)) == uint16_t(1)
+        assert binop(f, '&')(uint16_t(0xA5A5), uint16_t(0xAAAA)) == uint16_t(0xA0A0)
+        assert binop(f, '^')(uint16_t(0xA5A5), uint16_t(0xAAAA)) == uint16_t(0x0F0F)
+        assert binop(f, '|')(uint16_t(0xA5A5), uint16_t(0xAAAA)) == uint16_t(0xAFAF)
+
+    def test_binop_uint32_uint32(self):
+        f = self.compile(binop_f, [int, uint32_t, uint32_t], uint32_t)
+        assert binop(f, '+')(uint32_t(2**32-1), uint32_t(2**32-1)) == uint32_t(2**32-2)
+        assert binop(f, '-')(uint32_t(1), uint32_t(2**32-1)) == uint32_t(2)
+        assert binop(f, '*')(uint32_t(2**32-1), uint32_t(2**32-1)) == uint32_t(1)
+        # assert binop(f, '/')(uint32_t(2**32-1), uint32_t(2)) == uint32_t(2**31-1)
+        # assert binop(f, '/')(uint32_t(2**32-1), uint32_t(2**32-1)) == uint32_t(1)
+        # assert binop(f, '%')(uint32_t(2**32-1), uint32_t(4)) == uint32_t(3)
+        # assert binop(f, '%')(uint32_t(2**32-1), uint32_t(2**32-2)) == uint32_t(1)
+        assert binop(f, '<<')(uint32_t(2**32-1), uint32_t(0)) == uint32_t(2**32-1)
+        assert binop(f, '<<')(uint32_t(2**32-1), uint32_t(2)) == uint32_t(2**32-4)
+        assert binop(f, '<<')(uint32_t(2**32-1), uint32_t(31)) == uint32_t(2**31)
+        assert binop(f, '>>')(uint32_t(2**32-1), uint32_t(0)) == uint32_t(2**32-1)
+        assert binop(f, '>>')(uint32_t(2**32-1), uint32_t(2)) == uint32_t(2**30-1)
+        assert binop(f, '>>')(uint32_t(2**32-1), uint32_t(31)) == uint32_t(1)
+        assert binop(f, '&')(uint32_t(0xA5A5A5A5), uint32_t(0xAAAAAAAA)) == uint32_t(0xA0A0A0A0)
+        assert binop(f, '^')(uint32_t(0xA5A5A5A5), uint32_t(0xAAAAAAAA)) == uint32_t(0x0F0F0F0F)
+        assert binop(f, '|')(uint32_t(0xA5A5A5A5), uint32_t(0xAAAAAAAA)) == uint32_t(0xAFAFAFAF)
+
+    def test_binop_uint64_uint64(self):
+        f = self.compile(binop_f, [int, uint64_t, uint64_t], uint64_t)
+        assert binop(f, '+')(uint64_t(2**64-1), uint64_t(2**64-1)) == uint64_t(2**64-2)
+        assert binop(f, '-')(uint64_t(1), uint64_t(2**64-1)) == uint64_t(2)
+        assert binop(f, '*')(uint64_t(2**64-1), uint64_t(2**64-1)) == uint64_t(1)
+        # assert binop(f, '/')(uint64_t(2**64-1), uint64_t(2)) == uint64_t(2**63-1)
+        # assert binop(f, '/')(uint64_t(2**64-1), uint64_t(2**64-1)) == uint64_t(1)
+        # assert binop(f, '%')(uint64_t(2**64-1), uint64_t(4)) == uint64_t(3)
+        # assert binop(f, '%')(uint64_t(2**64-1), uint64_t(2**64-2)) == uint64_t(1)
+        assert binop(f, '<<')(uint64_t(2**64-1), uint64_t(0)) == uint64_t(2**64-1)
+        assert binop(f, '<<')(uint64_t(2**64-1), uint64_t(2)) == uint64_t(2**64-4)
+        assert binop(f, '<<')(uint64_t(2**64-1), uint64_t(63)) == uint64_t(2**63)
+        assert binop(f, '>>')(uint64_t(2**64-1), uint64_t(0)) == uint64_t(2**64-1)
+        assert binop(f, '>>')(uint64_t(2**64-1), uint64_t(2)) == uint64_t(2**62-1)
+        assert binop(f, '>>')(uint64_t(2**64-1), uint64_t(63)) == uint64_t(1)
+        assert binop(f, '&')(uint64_t(0xA5A5A5A5A5A5A5A5), uint64_t(0xAAAAAAAAAAAAAAAA))\
+               == uint64_t(0xA0A0A0A0A0A0A0A0)
+        assert binop(f, '^')(uint64_t(0xA5A5A5A5A5A5A5A5), uint64_t(0xAAAAAAAAAAAAAAAA))\
+               == uint64_t(0x0F0F0F0F0F0F0F0F)
+        assert binop(f, '|')(uint64_t(0xA5A5A5A5A5A5A5A5), uint64_t(0xAAAAAAAAAAAAAAAA))\
+               == uint64_t(0xAFAFAFAFAFAFAFAF)
+
+
+class TestTranslated(TestEmulated):
+    def compile(self, f, a, r):
+        a = [rarithmetic.intmask if x is int else x for x in a]
+        l = {'f': f, 'a': a, 'r': r,
+             'rbigint': rbigint.rbigint,
+             'unsigned': unsigned}
+        exec("""def entrypoint(argv):
+                    assert len(argv) == 1 + len(a)
+                    o = f(%s)
+                    assert isinstance(o, r)
+                    print str(unsigned(o))
+                    return 0""" % (",".join("a[%d](rbigint.fromstr(argv[%d]).ulonglongmask())" % (i,1+i) for i in xrange(len(a)))), l)
+        def compile(entry_point):
+            t = TranslationContext()
+            ann = t.buildannotator()
+            ann.build_types(entry_point, [s_list_of_strings])
+            t.buildrtyper().specialize()
+            cbuilder = CStandaloneBuilder(t, entry_point, t.config)
+            cbuilder.generate_source()
+            cbuilder.compile()
+            if option is not None and option.view:
+                t.view()
+            return t, cbuilder
+        t, cbuilder = compile(l['entrypoint'])
+        def cmdexec(*v):
+            o = cbuilder.cmdexec([str(x) for x in v])
+            return r(unsigned(o))
+        return cmdexec
+
+
+class TestJitted(TestEmulated, LLJitMixin):
+    def compile(self, f, a, r):
+        l = {'f': f, 'a': a, 'r': r,
+             'JitDriver': JitDriver}
+        arg_list = ",".join("i%d" % i for i in xrange(len(a)))
+        green_list = ",".join("'i%d'" % i for i in xrange(len(a)) if a[i] is int)
+        red_list = ",".join("'i%d'" % i for i in xrange(len(a)) if a[i] is not int)
+        kwarg_list = ",".join("i%d=i%d" % (i,i) for i in xrange(len(a)))
+        exec("""if 1:
+        driver = JitDriver(greens=[%s], reds=['it', %s])
+        def entrypoint(%s, it):
+            res = r(0)
+            while it > 0:
+                driver.can_enter_jit(it=it, %s)
+                driver.jit_merge_point(it=it, %s)
+                res = f(%s)
+                it -= 1
+            return res""" % (green_list, red_list, arg_list,
+                             kwarg_list, kwarg_list, arg_list), l)
+        def run(*v):
+            arg = list(v)
+            arg.append(7)
+            res = self.meta_interp(l['entrypoint'], arg, backendopt=True, inline=True)
+            self.check_trace_count(1)
+            return res
+        return run
+

--- a/emulator/types.py
+++ b/emulator/types.py
@@ -1,7 +1,54 @@
+from rpython.rlib import rarithmetic
+from rpython.rtyper import rint
+from rpython.rtyper.error import TyperError
+from rpython.rtyper.lltypesystem import rffi  # sets up predefined types
 
-from rpython.rtyper.lltypesystem import rffi
 
-uint8_t = rffi.r_uchar
-uint16_t = rffi.r_ushort
-uint32_t = rffi.r_uint
-uint64_t = rffi.r_ulonglong
+unsigned = rarithmetic.r_uint64
+signed = rarithmetic.r_int64
+
+
+def make_uint(bits):
+    # mask = (2 ** bits) - 1
+    storage = rarithmetic.build_int(None, False, bits)
+    # tp = type("uint%d_t" % bits, (base_uint,), {"MASK": unsigned(mask),
+    #                                             "BITS": bits,
+    #                                             "STORE": storage})
+    # return tp
+    return storage
+
+
+uint8_t = make_uint(8)
+uint16_t = make_uint(16)
+uint32_t = make_uint(32)
+uint64_t = make_uint(64)
+
+
+# _wrap_repr = rint.unsignedlonglong_repr
+# _wrap_prefix = 'ullong_'
+_wrap_repr = rint.unsigned_repr
+_wrap_prefix = 'uint_'
+
+
+_rint_rtype_template = rint._rtype_template
+def _rtype_template(hop, func):
+    """Write a simple operation implementing the given 'func'.
+    It must be an operation that cannot raise.
+    """
+    try:
+        return _rint_rtype_template(hop, func)
+    except TyperError:
+        r_result = hop.r_result
+        repr = _wrap_repr
+        if func.startswith(('lshift', 'rshift')):
+            repr2 = rint.signed_repr
+        else:
+            repr2 = repr
+        vlist = hop.inputargs(repr, repr2)
+
+        hop.exception_cannot_occur()
+
+        v_res = hop.genop(_wrap_prefix+func, vlist, resulttype=repr)
+        v_res = hop.llops.convertvar(v_res, repr, r_result)
+        return v_res
+rint._rtype_template = _rtype_template

--- a/emulator/types.py
+++ b/emulator/types.py
@@ -2,7 +2,7 @@ from rpython.rlib import rarithmetic
 from rpython.rtyper import rint
 from rpython.rtyper.error import TyperError
 from rpython.rtyper.lltypesystem import rffi  # sets up predefined types
-
+from rpython.rtyper.lltypesystem.lltype import Bool
 
 unsigned = rarithmetic.r_uint64
 signed = rarithmetic.r_int64
@@ -25,9 +25,7 @@ uint64_t = make_uint(64)
 
 
 # _wrap_repr = rint.unsignedlonglong_repr
-# _wrap_prefix = 'ullong_'
 _wrap_repr = rint.unsigned_repr
-_wrap_prefix = 'uint_'
 
 
 _rint_rtype_template = rint._rtype_template
@@ -38,6 +36,11 @@ def _rtype_template(hop, func):
     try:
         return _rint_rtype_template(hop, func)
     except TyperError:
+        s_int1, s_int2 = hop.args_s
+        if (not (s_int1.unsigned or s_int2.unsigned)
+            or not s_int1.nonneg or not s_int2.nonneg):
+            raise TyperError("binary ops for small signed ints not implemented")
+
         r_result = hop.r_result
         repr = _wrap_repr
         if func.startswith(('lshift', 'rshift')):
@@ -48,7 +51,54 @@ def _rtype_template(hop, func):
 
         hop.exception_cannot_occur()
 
-        v_res = hop.genop(_wrap_prefix+func, vlist, resulttype=repr)
+        v_res = hop.genop(repr.opprefix+func, vlist, resulttype=repr)
         v_res = hop.llops.convertvar(v_res, repr, r_result)
         return v_res
 rint._rtype_template = _rtype_template
+
+
+_rint_rtype_compare_template = rint._rtype_compare_template
+def _rtype_compare_template(hop, func):
+    try:
+        return _rint_rtype_compare_template(hop, func)
+    except TyperError:
+        s_int1, s_int2 = hop.args_s
+        if (not (s_int1.unsigned or s_int2.unsigned)
+            or not s_int1.nonneg or not s_int2.nonneg):
+            raise TyperError("comparing small signed ints not implemented")
+
+        repr = _wrap_repr
+        vlist = hop.inputargs(repr, repr)
+        hop.exception_is_here()
+        return hop.genop(repr.opprefix + func, vlist, resulttype=Bool)
+rint._rtype_compare_template = _rtype_compare_template
+
+
+_rint_IntegerRepr_rtype_neg = rint.IntegerRepr.rtype_neg
+def _rtype_neg(self, hop):
+    try:
+        return _rint_IntegerRepr_rtype_neg(self, hop)
+    except TyperError:
+        if not hop.s_result.unsigned:
+            raise TyperError("neg(...) for small signed ints not implemented")
+        self = self.as_int
+        vlist = hop.inputargs(_wrap_repr)
+        zero = _wrap_repr.lowleveltype._defl()
+        vlist.insert(0, hop.inputconst(_wrap_repr.lowleveltype, zero))
+        v_res = hop.genop(_wrap_repr.opprefix + 'sub', vlist, resulttype=_wrap_repr)
+        return hop.llops.convertvar(v_res, _wrap_repr, self)
+rint.IntegerRepr.rtype_neg = _rtype_neg
+
+
+_rint_IntegerRepr_rtype_invert = rint.IntegerRepr.rtype_invert
+def _rtype_invert(self, hop):
+    try:
+        return _rint_IntegerRepr_rtype_invert(self, hop)
+    except TyperError:
+        if not hop.s_result.unsigned:
+            raise TyperError("invert(...) for small signed ints not implemented")
+        self = self.as_int
+        vlist = hop.inputargs(_wrap_repr)
+        v_res = hop.genop(_wrap_repr.opprefix + 'invert', vlist, resulttype=_wrap_repr)
+        return hop.llops.convertvar(v_res, _wrap_repr, self)
+rint.IntegerRepr.rtype_invert = _rtype_invert

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -rf


### PR DESCRIPTION
Normally RPython doesn't implement low-level operations for small integer types. However, that is exactly what is needed for this project. As it turns out, it is fairly simple to modify the RTyper to implement low-level operations for small unsigned integer types such that it:

1. converts arguments to `Unsigned`,
2. uses the standard `uint_...` operation,
3. converts the result back to the expected type...
    * ...using a cast when the JIT is disabled;
    * ...using a `uint_and` when the JIT is enabled.

The key is to monkeypatch the `rint._rtype_template`, `rint._rtype_compare_template`,  `rint.IntegerRepr.rtype_neg`, `rint.IntegerRepr.rtype_invert` functions to:

1. try to call the original function for regular ints,
2. if it fails, make sure the args are unsigned and implement the steps above using the existing code as a template.